### PR TITLE
Potential fix for code scanning alert no. 8: Incomplete multi-character sanitization (superseded)

### DIFF
--- a/scripts/i18n-compare.js
+++ b/scripts/i18n-compare.js
@@ -186,7 +186,12 @@ function normalizeStructure(html) {
   s = s.replace(/^\uFEFF/, '');
   
   // Remove comments (with length limit to prevent ReDoS)
-  s = s.replace(/<!--[\s\S]{0,10000}?-->/g, '');
+  // Fix: Remove HTML comments repeatedly until none remain to ensure full sanitization
+  let prev;
+  do {
+    prev = s;
+    s = s.replace(/<!--[\s\S]{0,10000}?-->/g, '');
+  } while (s !== prev);
   
   // Remove script and style blocks using the safe function
   s = stripBetweenSafe(s, '<script', '</script>');


### PR DESCRIPTION
Superseded by the fix already on main that uses `stripBetweenSafe()` with iteration limits and size checks.

- Keeps complexity linear vs repeated-regex passes
- Consistent with script/style removal strategy
- Code scanning alert #8 expected to resolve on next run